### PR TITLE
Add editor default indent

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -26,60 +26,57 @@
 	},
 	"Styled-Component": {
 		"prefix": "sc",
-		"body": "const ${1} = styled.${2}`\n  ${3}\n`;",
+		"body": "const ${1} = styled.${2}`\n\t${3}\n`;",
 		"description": "Styled-Component"
 	},
 	"Export styled-component": {
 		"prefix": "exsc",
-		"body": "export const ${1} = styled.${2}`\n  ${3}\n`;",
+		"body": "export const ${1} = styled.${2}`\n\t${3}\n`;",
 		"description": "Export styled-component"
 	},
 	"createGlobalStyle": {
 		"prefix": "scg",
-		"body": "const Global${1} = createGlobalStyle`\n  ${2}\n`;",
+		"body": "const Global${1} = createGlobalStyle`\n\t${2}\n`;",
 		"description": "createGlobalStyle"
 	},
 	"Export createGlobalStyle": {
 		"prefix": "exscg",
-		"body": "export const Global${1} = createGlobalStyle`\n  ${2}\n`;",
+		"body": "export const Global${1} = createGlobalStyle`\n\t${2}\n`;",
 		"description": "Export createGlobalStyle"
 	},
 	"Styled-Component from existing component": {
 		"prefix": "scc",
-		"body": "const ${1} = styled(${2})`\n  ${3}\n`;",
+		"body": "const ${1} = styled(${2})`\n\t${3}\n`;",
 		"description": "Styled-Component from existing component"
 	},
 	"Export styled-component from existing component": {
 		"prefix": "exscc",
-		"body": "export const ${1} = styled(${2})`\n  ${3}\n`;",
+		"body": "export const ${1} = styled(${2})`\n\t${3}\n`;",
 		"description": "Export styled-component from existing component"
 	},
 	"Styled-Components file": {
 		"prefix": "scf",
-		"body":
-			"import styled from 'styled-components';\n\nconst ${1} = styled.${2}`\n  ${3}\n`;\n\nexport default ${1};",
+		"body": "import styled from 'styled-components';\n\nconst ${1} = styled.${2}`\n\t${3}\n`;\n\nexport default ${1};",
 		"description": "Styled-Components file"
 	},
 	"ThemeProvider": {
 		"prefix": "ThemeProvider",
-		"body": "<ThemeProvider theme={${1}}>\n  ${2}\n</ThemeProvider>",
+		"body": "<ThemeProvider theme={${1}}>\n\t${2}\n</ThemeProvider>",
 		"description": "ThemeProvider"
 	},
 	"styled-component theme": {
 		"prefix": "sct",
-		"body":
-			"// Define what props.theme will look like\nconst theme = {\n  ${1}: '${2}'\n};",
+		"body": "// Define what props.theme will look like\nconst theme = {\n\t${1}: '${2}'\n};",
 		"description": "styled-component theme"
 	},
 	"Styled-Component with attributes": {
 		"prefix": "scattrs",
-		"body": "const ${1} = styled.${2}.attrs({\n  ${3}: ${4}\n})`\n  ${5}\n`;",
+		"body": "const ${1} = styled.${2}.attrs({\n\t${3}: ${4}\n})`\n\t${5}\n`;",
 		"description": "Styled-Component with attributes"
 	},
 	"Export styled-component with attributes": {
 		"prefix": "exscattrs",
-		"body":
-			"export const ${1} = styled.${2}.attrs({\n  ${3}: ${4}\n})`\n  ${5}\n`;",
+		"body": "export const ${1} = styled.${2}.attrs({\n\t${3}: ${4}\n})`\n\t${5}\n`;",
 		"description": "Export styled-component with attributes"
 	},
 	"Use props.theme inside styled-component": {


### PR DESCRIPTION
I noticed that snippet always add 2 spaces to indent the snippet, then I added `\t` notation to get editor default indent...